### PR TITLE
JWT 생성 및 기반 인증 / 인가 Security 설정하기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,12 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.flywaydb:flyway-core'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testImplementation 'io.mockk:mockk:1.14.5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.25'
+    id 'jacoco'
 }
 
 group = 'kr.co.archan'
@@ -63,4 +64,15 @@ allOpen {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)   // CI/CD, SonarQube 연동용
+        csv.required.set(false)
+        html.required.set(true)  // 사람이 보기 편한 리포트
+    }
 }

--- a/src/main/kotlin/kr/co/archan/reflect/ReflectBeApplication.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/ReflectBeApplication.kt
@@ -1,10 +1,12 @@
 package kr.co.archan.reflect
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 @SpringBootApplication
 class ReflectBeApplication
 

--- a/src/main/kotlin/kr/co/archan/reflect/auth/domain/AccessToken.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/domain/AccessToken.kt
@@ -1,0 +1,8 @@
+package kr.co.archan.reflect.auth.domain
+
+import java.time.Instant
+
+data class AccessToken (
+    val value: String,
+    val expiresAt: Instant,
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/domain/MemberPrincipal.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/domain/MemberPrincipal.kt
@@ -1,0 +1,6 @@
+package kr.co.archan.reflect.auth.domain
+
+data class MemberPrincipal (
+    val memberId: Long,
+    val email: String,
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/domain/RefreshToken.kt
@@ -1,0 +1,9 @@
+package kr.co.archan.reflect.auth.domain
+
+import java.time.Instant
+
+data class RefreshToken (
+    val value: String,
+    val memberId: String,
+    val expiresAt: Instant
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtAuthException.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtAuthException.kt
@@ -1,0 +1,9 @@
+package kr.co.archan.reflect.auth.exception.common
+
+import kr.co.archan.reflect.auth.exception.types.JwtAuthErrorSpec
+import kr.co.archan.reflect.global.exception.base.ApiException
+import org.springframework.http.HttpStatus
+
+open class JwtAuthException(spec: JwtAuthErrorSpec) : ApiException(spec) {
+    override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED
+}

--- a/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtClaimFormatException.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtClaimFormatException.kt
@@ -1,0 +1,7 @@
+package kr.co.archan.reflect.auth.exception.common
+
+import kr.co.archan.reflect.auth.exception.types.JwtAuthErrorSpec
+
+class JwtClaimFormatException : JwtAuthException(
+    JwtAuthErrorSpec.CLAIM_FORMAT_INVALID
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtConversionException.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtConversionException.kt
@@ -1,0 +1,7 @@
+package kr.co.archan.reflect.auth.exception.common
+
+import kr.co.archan.reflect.auth.exception.types.JwtAuthErrorSpec
+
+class JwtConversionException : JwtAuthException(
+    JwtAuthErrorSpec.CONVERSION_FAILED
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtRequiredClaimMissingException.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/exception/common/JwtRequiredClaimMissingException.kt
@@ -1,0 +1,7 @@
+package kr.co.archan.reflect.auth.exception.common
+
+import kr.co.archan.reflect.auth.exception.types.JwtAuthErrorSpec
+
+class JwtRequiredClaimMissingException : JwtAuthException(
+    JwtAuthErrorSpec.REQUIRED_CLAIM_MISSING
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/exception/types/JwtAuthErrorSpec.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/exception/types/JwtAuthErrorSpec.kt
@@ -1,0 +1,24 @@
+package kr.co.archan.reflect.auth.exception.types
+
+import kr.co.archan.reflect.global.exception.types.ApiErrorSpec
+
+enum class JwtAuthErrorSpec(
+    override val systemMessage: String,
+    override val userMessage: String
+) : ApiErrorSpec {
+    
+    REQUIRED_CLAIM_MISSING(
+        systemMessage = "JWT에 필수 클레임이 누락되었습니다",
+        userMessage = "인증 토큰이 유효하지 않습니다"
+    ),
+    
+    CLAIM_FORMAT_INVALID(
+        systemMessage = "JWT 클레임의 형식이 올바르지 않습니다",
+        userMessage = "인증 토큰이 유효하지 않습니다"
+    ),
+    
+    CONVERSION_FAILED(
+        systemMessage = "JWT를 Authentication으로 변환하는 중 오류가 발생했습니다",
+        userMessage = "인증 처리 중 오류가 발생했습니다"
+    )
+}

--- a/src/main/kotlin/kr/co/archan/reflect/auth/properties/JwtProperties.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/properties/JwtProperties.kt
@@ -1,0 +1,17 @@
+package kr.co.archan.reflect.auth.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "security.jwt")
+data class JwtProperties (
+    val issuer: String,
+    val audience: String,
+    val secret: String,
+    val accessTokenTtlSeconds: Long,
+    val refreshTokenTtlSeconds: Long,
+    val refreshCookieEnabled: Boolean,
+    val refreshCookieName: String,
+    val refreshCookieSecure: Boolean,
+    val refreshCookiePath: String,
+    val refreshCookieSameSite: String
+)

--- a/src/main/kotlin/kr/co/archan/reflect/auth/provider/AccessTokenProvider.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/provider/AccessTokenProvider.kt
@@ -1,0 +1,43 @@
+package kr.co.archan.reflect.auth.provider
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.MACSigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import kr.co.archan.reflect.auth.domain.AccessToken
+import kr.co.archan.reflect.auth.properties.JwtProperties
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.*
+
+@Component
+class AccessTokenProvider (
+    private val properties: JwtProperties
+){
+    private val signer = MACSigner(properties.secret.toByteArray(Charsets.UTF_8))
+
+    fun provideAccessToken(memberId: Long, email: String): AccessToken {
+        val now = Instant.now()
+        val exp = now.plusSeconds(properties.accessTokenTtlSeconds)
+
+        val header = JWSHeader.Builder(JWSAlgorithm.HS256)
+            .type(JOSEObjectType.JWT)
+            .build()
+
+        val claims = JWTClaimsSet.Builder()
+            .subject(memberId.toString())
+            .issuer(properties.issuer)
+            .audience(properties.audience)
+            .issueTime(Date.from(now))
+            .expirationTime(Date.from(exp))
+            .jwtID(UUID.randomUUID().toString())
+            .claim("member_id", memberId.toString())
+            .claim("email", email)
+            .build()
+
+        val jwt = SignedJWT(header, claims).apply { sign(signer) }.serialize()
+        return AccessToken(value = jwt, expiresAt = exp)
+    }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/auth/provider/RefreshTokenProvider.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/provider/RefreshTokenProvider.kt
@@ -1,0 +1,32 @@
+package kr.co.archan.reflect.auth.provider
+
+import kr.co.archan.reflect.auth.domain.RefreshToken
+import kr.co.archan.reflect.auth.properties.JwtProperties
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.*
+
+@Component
+class RefreshTokenProvider (
+    private val properties: JwtProperties
+){
+    private val secureRandom = SecureRandom()
+
+    fun provideRefreshToken(memberId: Long): RefreshToken {
+        val value = randomToken()
+        val expiresAt = Instant.now().plusSeconds(properties.refreshTokenTtlSeconds)
+        return RefreshToken(
+            value = value,
+            memberId = memberId.toString(),
+            expiresAt = expiresAt
+        )
+    }
+
+    private fun randomToken(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+}

--- a/src/main/kotlin/kr/co/archan/reflect/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/repository/RefreshTokenRepository.kt
@@ -1,0 +1,31 @@
+package kr.co.archan.reflect.auth.repository
+
+import kr.co.archan.reflect.auth.domain.RefreshToken
+import kr.co.archan.reflect.global.util.Crypto
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@Repository
+class RefreshTokenRepository (
+    private val stringRedisTemplate: StringRedisTemplate
+){
+    private fun key(value: String) = "rt:${Crypto.sha256(value)}"
+
+    fun save(token: RefreshToken) {
+        val ttl = Duration.between(Instant.now(), token.expiresAt)
+        stringRedisTemplate.opsForValue().set(key(token.value), token.memberId, ttl)
+    }
+
+    fun findByValue(value: String): RefreshToken? {
+        val memberId = stringRedisTemplate.opsForValue().get(key(value)) ?: return null
+        val expireAt = stringRedisTemplate.getExpire(key(value), TimeUnit.SECONDS)
+        return RefreshToken(value, memberId, Instant.now().plusSeconds(expireAt))
+    }
+
+    fun delete(value: String) {
+        stringRedisTemplate.delete(key(value))
+    }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/auth/repository/RefreshTokenRepository.kt
@@ -10,9 +10,10 @@ import java.util.concurrent.TimeUnit
 
 @Repository
 class RefreshTokenRepository (
-    private val stringRedisTemplate: StringRedisTemplate
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val crypto: Crypto
 ){
-    private fun key(value: String) = "rt:${Crypto.sha256(value)}"
+    private fun key(value: String) = "rt:${crypto.sha256WithNoSalt(value)}"
 
     fun save(token: RefreshToken) {
         val ttl = Duration.between(Instant.now(), token.expiresAt)

--- a/src/main/kotlin/kr/co/archan/reflect/global/exception/dto/BasicErrorResponse.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/exception/dto/BasicErrorResponse.kt
@@ -1,0 +1,8 @@
+package kr.co.archan.reflect.global.exception.dto
+
+class BasicErrorResponse(
+    override val title: String,
+    override val status: Int,
+    override val detail: String?,
+    override val instance: String?
+) : ApiErrorResponseSpec

--- a/src/main/kotlin/kr/co/archan/reflect/global/security/config/JwtConfig.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/security/config/JwtConfig.kt
@@ -1,0 +1,34 @@
+package kr.co.archan.reflect.global.security.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import javax.crypto.spec.SecretKeySpec
+
+@Configuration
+class JwtConfig(
+    @Value("\${security.jwt.secret}") private val secret: String,
+    @Value("\${security.jwt.issuer}") private val issuer: String,
+) {
+
+    @Bean
+    fun jwtDecoder(): JwtDecoder {
+        val key = SecretKeySpec(secret.toByteArray(), "HmacSHA256")
+
+        val decoder = NimbusJwtDecoder
+            .withSecretKey(key)
+            .macAlgorithm(MacAlgorithm.HS256)  // alg 고정
+            .build()
+
+        // 기본(exp/nbf) + issuer 검증
+        val validator = JwtValidators.createDefaultWithIssuer(issuer)
+
+        decoder.setJwtValidator(DelegatingOAuth2TokenValidator(validator))
+        return decoder
+    }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/security/config/SecurityConfig.kt
@@ -1,0 +1,36 @@
+package kr.co.archan.reflect.global.security.config
+
+import kr.co.archan.reflect.global.security.converter.JwtAuthConverter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+
+@Configuration
+@EnableMethodSecurity(prePostEnabled = true)
+class SecurityConfig(
+    private val jwtAuthConverter: JwtAuthConverter,
+    private val authenticationEntryPoint: AuthenticationEntryPoint,
+    private val accessDeniedHandler: AccessDeniedHandler,
+) {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it.requestMatchers("/member/signup").permitAll()
+                it.requestMatchers("/member/login").permitAll()
+                it.anyRequest().authenticated()
+            }
+            .oauth2ResourceServer { rs ->
+                rs.authenticationEntryPoint(authenticationEntryPoint)
+                rs.accessDeniedHandler(accessDeniedHandler)
+                rs.jwt { it.jwtAuthenticationConverter(jwtAuthConverter) }
+            }
+            .build()
+}

--- a/src/main/kotlin/kr/co/archan/reflect/global/security/config/SecurityHandlersConfig.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/security/config/SecurityHandlersConfig.kt
@@ -1,0 +1,70 @@
+package kr.co.archan.reflect.global.security.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import kr.co.archan.reflect.global.exception.dto.BasicErrorResponse
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.access.AccessDeniedHandler
+
+@Configuration
+class SecurityHandlersConfig(
+    private val objectMapper: ObjectMapper
+) {
+
+    @Bean
+    fun authenticationEntryPoint(): AuthenticationEntryPoint =
+        AuthenticationEntryPoint { req, res, ex ->
+            val raw = (ex.cause?.message ?: ex.message).orEmpty()
+
+            val (title, detail) = when {
+                raw.contains("expired", true) ->
+                    "Token_Expired" to "토큰이 만료되었습니다."
+
+                raw.contains("Invalid issuer", true) || raw.contains("issuer", true) || raw.contains(" iss", true) ->
+                    "Invalid_Issuer" to "토큰 발급자가 올바르지 않습니다."
+
+                raw.contains("Invalid audience", true) || raw.contains("audience", true) ->
+                    "Invalid_Audience" to "토큰 대상(audience)이 올바르지 않습니다."
+
+                raw.contains("signature", true) || raw.contains("JWS", true) || raw.contains("MAC", true) ->
+                    "Invalid_Signature" to "토큰 서명이 유효하지 않습니다."
+
+                raw.contains("algorithm", true) ->
+                    "Invalid_Algorithm" to "허용되지 않은 서명 알고리즘입니다."
+
+                else ->
+                    "Invalid_Token" to "유효하지 않은 토큰입니다."
+            }
+
+            val basicErrorResponse = BasicErrorResponse(
+                title = title,
+                status = HttpStatus.UNAUTHORIZED.value(),
+                detail = detail,
+                instance = req.requestURI
+            )
+
+            // RFC 6750 권장 헤더
+            res.setHeader("WWW-Authenticate", """Bearer error="invalid_token", error_description="$title"""")
+            res.status = HttpStatus.UNAUTHORIZED.value()
+            res.characterEncoding = Charsets.UTF_8.name()
+            res.writer.write(objectMapper.writeValueAsString(basicErrorResponse))
+        }
+
+    @Bean
+    fun accessDeniedHandler(): AccessDeniedHandler =
+        AccessDeniedHandler { req, res, _ ->
+            val basicErrorResponse = BasicErrorResponse(
+                title = "Permission_Denied",
+                status = HttpStatus.FORBIDDEN.value(),
+                detail = "접근 권한이 존재하지 않습니다.",
+                instance = req.requestURI
+            )
+
+            res.status = HttpStatus.FORBIDDEN.value()
+            res.characterEncoding = Charsets.UTF_8.name()
+            res.writer.write(objectMapper.writeValueAsString(basicErrorResponse))
+        }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverter.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverter.kt
@@ -1,0 +1,22 @@
+package kr.co.archan.reflect.global.security.converter
+
+import kr.co.archan.reflect.auth.domain.MemberPrincipal
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAuthConverter : Converter<Jwt, AbstractAuthenticationToken> {
+    override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+        val principal = MemberPrincipal(
+            memberId = jwt.getClaimAsString("member_id").toLong(),
+            email = jwt.getClaimAsString("email")
+        )
+        val roles = (jwt.claims["roles"] as? Collection<*>)?.map { it.toString() } ?: listOf("USER")
+        val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
+        return UsernamePasswordAuthenticationToken(principal, "N/A", authorities)
+    }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverter.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverter.kt
@@ -1,6 +1,10 @@
 package kr.co.archan.reflect.global.security.converter
 
 import kr.co.archan.reflect.auth.domain.MemberPrincipal
+import kr.co.archan.reflect.auth.exception.common.JwtAuthException
+import kr.co.archan.reflect.auth.exception.common.JwtClaimFormatException
+import kr.co.archan.reflect.auth.exception.common.JwtConversionException
+import kr.co.archan.reflect.auth.exception.common.JwtRequiredClaimMissingException
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -11,12 +15,32 @@ import org.springframework.stereotype.Component
 @Component
 class JwtAuthConverter : Converter<Jwt, AbstractAuthenticationToken> {
     override fun convert(jwt: Jwt): AbstractAuthenticationToken {
-        val principal = MemberPrincipal(
-            memberId = jwt.getClaimAsString("member_id").toLong(),
-            email = jwt.getClaimAsString("email")
-        )
-        val roles = (jwt.claims["roles"] as? Collection<*>)?.map { it.toString() } ?: listOf("USER")
-        val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
-        return UsernamePasswordAuthenticationToken(principal, "N/A", authorities)
+        try {
+            // 필수 클레임 검증
+            val memberIdStr = jwt.getClaimAsString("member_id")
+                ?: throw JwtRequiredClaimMissingException()
+            
+            val email = jwt.getClaimAsString("email")
+                ?: throw JwtRequiredClaimMissingException()
+            
+            // memberId 타입 변환
+            val memberId = try {
+                memberIdStr.toLong()
+            } catch (e: NumberFormatException) {
+                throw JwtClaimFormatException()
+            }
+            
+            val principal = MemberPrincipal(memberId = memberId, email = email)
+            
+            val roles = (jwt.claims["roles"] as? Collection<*>)?.map { it.toString() } ?: listOf("USER")
+            val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
+            
+            return UsernamePasswordAuthenticationToken(principal, "N/A", authorities)
+            
+        } catch (e: JwtAuthException) {
+            throw e
+        } catch (e: Exception) {
+            throw JwtConversionException()
+        }
     }
 }

--- a/src/main/kotlin/kr/co/archan/reflect/global/util/Crypto.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/util/Crypto.kt
@@ -1,0 +1,11 @@
+package kr.co.archan.reflect.global.util
+
+import java.security.MessageDigest
+import java.util.*
+
+object Crypto {
+     fun sha256(s: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest(s.toByteArray()))
+    }
+}

--- a/src/main/kotlin/kr/co/archan/reflect/global/util/Crypto.kt
+++ b/src/main/kotlin/kr/co/archan/reflect/global/util/Crypto.kt
@@ -1,11 +1,20 @@
 package kr.co.archan.reflect.global.util
 
-import java.security.MessageDigest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 import java.util.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
-object Crypto {
-     fun sha256(s: String): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest(s.toByteArray()))
+@Component
+class Crypto(
+    @Value("\${security.sha.secret}")
+    private val secretKey: String
+) {
+    fun sha256WithNoSalt(s: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        val secretKeySpec = SecretKeySpec(secretKey.toByteArray(), "HmacSHA256")
+        mac.init(secretKeySpec)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(s.toByteArray()))
     }
 }

--- a/src/test/kotlin/kr/co/archan/reflect/auth/provider/AccessTokenProviderTest.kt
+++ b/src/test/kotlin/kr/co/archan/reflect/auth/provider/AccessTokenProviderTest.kt
@@ -1,0 +1,87 @@
+package kr.co.archan.reflect.auth.provider
+
+import com.nimbusds.jwt.SignedJWT
+import io.mockk.every
+import io.mockk.mockk
+import kr.co.archan.reflect.auth.properties.JwtProperties
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.math.abs
+
+class AccessTokenProviderTest {
+
+    @Test
+    @DisplayName("provideAccessToken - JWT 토큰 생성 기본 기능")
+    fun `provideAccessToken - JWT 토큰 생성 기본 기능`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { issuer } returns "test-issuer"
+            every { audience } returns "test-audience"
+            every { secret } returns "test-secret-key-for-jwt-signing-must-be-long-enough"
+            every { accessTokenTtlSeconds } returns 3600L
+        }
+        
+        val accessTokenProvider = AccessTokenProvider(jwtProperties)
+        val memberId = 12345L
+        val email = "test@example.com"
+        val beforeCall = Instant.now()
+        
+        // when
+        val result = accessTokenProvider.provideAccessToken(memberId, email)
+        val afterCall = Instant.now()
+        
+        // then
+        assertNotNull(result)
+        
+        // 생성된 토큰 값이 null이 아니고 비어있지 않은지
+        assertNotNull(result.value)
+        assertFalse(result.value.isEmpty())
+        assertFalse(result.value.isBlank())
+        
+        // 만료시간이 현재 시간보다 미래인지
+        assertTrue(result.expiresAt.isAfter(beforeCall))
+        assertTrue(result.expiresAt.isAfter(afterCall))
+        
+        // 만료시간이 대략적으로 현재 시간 + TTL과 일치하는지, 테스트 실행 시간 고려하여 2초이내의 오차 허용
+        val expectedExpiry = beforeCall.plusSeconds(3600L)
+        val timeDifference = abs(result.expiresAt.epochSecond - expectedExpiry.epochSecond)
+        assertTrue(timeDifference <= 2) // 2초 이내 오차 허용
+        
+        // JWT 토큰을 파싱해서 클레임 검증
+        val signedJWT = SignedJWT.parse(result.value)
+        val claims = signedJWT.jwtClaimsSet
+        
+        // 토큰에 올바른 사용자 정보가 포함되어 있는지 검증
+        assertEquals(memberId.toString(), claims.subject)
+        assertEquals(email, claims.getStringClaim("email"))
+        assertEquals(memberId.toString(), claims.getStringClaim("member_id"))
+        assertEquals("test-issuer", claims.issuer)
+        assertEquals(listOf("test-audience"), claims.audience)
+    }
+
+    @Test
+    @DisplayName("provideAccessToken - TTL 오버플로우로 토큰 발급 실패")
+    fun `provideAccessToken - TTL 오버플로우로 토큰 발급 실패`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { issuer } returns "test-issuer"
+            every { audience } returns "test-audience"
+            every { secret } returns "test-secret-key-for-jwt-signing-must-be-long-enough"
+            every { accessTokenTtlSeconds } returns Long.MAX_VALUE // ← 오버플로우 유발
+        }
+        
+        val accessTokenProvider = AccessTokenProvider(jwtProperties)
+        val memberId = 12345L
+        val email = "test@example.com"
+        
+        // when & then
+        assertThrows<ArithmeticException> {
+            accessTokenProvider.provideAccessToken(memberId, email)
+        }
+    }
+}
+
+

--- a/src/test/kotlin/kr/co/archan/reflect/auth/provider/RefreshTokenProviderTest.kt
+++ b/src/test/kotlin/kr/co/archan/reflect/auth/provider/RefreshTokenProviderTest.kt
@@ -1,0 +1,129 @@
+package kr.co.archan.reflect.auth.provider
+
+import io.mockk.every
+import io.mockk.mockk
+import kr.co.archan.reflect.auth.properties.JwtProperties
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.util.*
+import kotlin.math.abs
+
+class RefreshTokenProviderTest {
+
+    @Test
+    @DisplayName("provideRefreshToken - 리프레시 토큰 생성 기본 기능")
+    fun `provideRefreshToken - 리프레시 토큰 생성 기본 기능`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { refreshTokenTtlSeconds } returns 604800L // 7일
+        }
+        
+        val refreshTokenProvider = RefreshTokenProvider(jwtProperties)
+        val memberId = 12345L
+        val beforeCall = Instant.now()
+        
+        // when
+        val result = refreshTokenProvider.provideRefreshToken(memberId)
+        val afterCall = Instant.now()
+        
+        // then
+        // RefreshToken 객체가 정상적으로 반환되는지
+        assertNotNull(result)
+        
+        // 생성된 토큰 값이 null이 아니고 비어있지 않은지
+        assertNotNull(result.value)
+        assertFalse(result.value.isEmpty())
+        assertFalse(result.value.isBlank())
+        
+        // memberId가 올바르게 설정되었는지
+        assertEquals(memberId.toString(), result.memberId)
+        
+        // 만료시간이 현재 시간보다 미래인지
+        assertTrue(result.expiresAt.isAfter(beforeCall))
+        assertTrue(result.expiresAt.isAfter(afterCall))
+        
+        // 만료시간이 대략적으로 현재 시간 + TTL과 일치하는지 (2초 이내 오차 허용)
+        val expectedExpiry = beforeCall.plusSeconds(604800L)
+        val timeDifference = abs(result.expiresAt.epochSecond - expectedExpiry.epochSecond)
+        assertTrue(timeDifference <= 2)
+    }
+
+    @Test
+    @DisplayName("provideRefreshToken - 랜덤 토큰 생성 검증")
+    fun `provideRefreshToken - 랜덤 토큰 생성 검증`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { refreshTokenTtlSeconds } returns 604800L
+        }
+        
+        val refreshTokenProvider = RefreshTokenProvider(jwtProperties)
+        val memberId = 12345L
+        
+        // when
+        val token1 = refreshTokenProvider.provideRefreshToken(memberId)
+        val token2 = refreshTokenProvider.provideRefreshToken(memberId)
+        
+        // then
+        // 동일한 memberId라도 매번 다른 토큰이 생성되어야 함
+        assertNotEquals(token1.value, token2.value)
+        
+        // 토큰 길이가 일정해야 함 (32바이트를 Base64 URL 인코딩하면 43자)
+        assertEquals(43, token1.value.length)
+        assertEquals(43, token2.value.length)
+        
+        // Base64 URL 인코딩 형식인지 확인 (패딩 없음)
+        assertFalse(token1.value.contains('='))
+        assertFalse(token2.value.contains('='))
+        assertTrue(token1.value.matches(Regex("^[A-Za-z0-9_-]+$")))
+        assertTrue(token2.value.matches(Regex("^[A-Za-z0-9_-]+$")))
+    }
+
+    @Test
+    @DisplayName("provideRefreshToken - 다른 memberId로 토큰 생성")
+    fun `provideRefreshToken - 다른 memberId로 토큰 생성`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { refreshTokenTtlSeconds } returns 604800L
+        }
+        
+        val refreshTokenProvider = RefreshTokenProvider(jwtProperties)
+        val memberId1 = 12345L
+        val memberId2 = 67890L
+        
+        // when
+        val token1 = refreshTokenProvider.provideRefreshToken(memberId1)
+        val token2 = refreshTokenProvider.provideRefreshToken(memberId2)
+        
+        // then
+        // 토큰 값은 다르지만 (랜덤 생성이므로)
+        assertNotEquals(token1.value, token2.value)
+        
+        // memberId는 각각 올바르게 설정되어야 함
+        assertEquals(memberId1.toString(), token1.memberId)
+        assertEquals(memberId2.toString(), token2.memberId)
+        
+        // 만료시간은 비슷해야 함 (거의 동시에 생성되었으므로)
+        val timeDifference = abs(token1.expiresAt.epochSecond - token2.expiresAt.epochSecond)
+        assertTrue(timeDifference <= 1)
+    }
+
+    @Test
+    @DisplayName("provideRefreshToken - TTL 오버플로우로 토큰 발급 실패")
+    fun `provideRefreshToken - TTL 오버플로우로 토큰 발급 실패`() {
+        // given
+        val jwtProperties = mockk<JwtProperties> {
+            every { refreshTokenTtlSeconds } returns Long.MAX_VALUE // ← 오버플로우 유발
+        }
+        
+        val refreshTokenProvider = RefreshTokenProvider(jwtProperties)
+        val memberId = 12345L
+        
+        // when & then
+        assertThrows<ArithmeticException> {
+            refreshTokenProvider.provideRefreshToken(memberId)
+        }
+    }
+}

--- a/src/test/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverterTest.kt
+++ b/src/test/kotlin/kr/co/archan/reflect/global/security/converter/JwtAuthConverterTest.kt
@@ -1,0 +1,181 @@
+package kr.co.archan.reflect.global.security.converter
+
+import io.mockk.every
+import io.mockk.mockk
+import kr.co.archan.reflect.auth.domain.MemberPrincipal
+import kr.co.archan.reflect.auth.exception.common.JwtClaimFormatException
+import kr.co.archan.reflect.auth.exception.common.JwtRequiredClaimMissingException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+
+class JwtAuthConverterTest {
+
+    private val jwtAuthConverter = JwtAuthConverter()
+
+    @Test
+    @DisplayName("JWT 변환 - 기본 권한 (roles 없음)")
+    fun `JWT 변환 - 기본 권한 (roles 없음)`() {
+        // given
+        val jwt = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "12345"
+            every { getClaimAsString("email") } returns "test@example.com"
+            every { claims } returns mapOf(
+                "member_id" to "12345",
+                "email" to "test@example.com"
+            )
+        }
+        
+        // when
+        val result = jwtAuthConverter.convert(jwt)
+        
+        // then
+        assertNotNull(result)
+        assertTrue(result is UsernamePasswordAuthenticationToken)
+        
+        // Principal 검증
+        val principal = result.principal as MemberPrincipal
+        assertEquals(12345L, principal.memberId)
+        assertEquals("test@example.com", principal.email)
+        
+        // 기본 권한 검증
+        assertEquals(1, result.authorities.size)
+        assertTrue(result.authorities.contains(SimpleGrantedAuthority("ROLE_USER")))
+        
+        // Credentials 검증
+        assertEquals("N/A", result.credentials)
+    }
+
+    @Test
+    @DisplayName("JWT 변환 - 커스텀 권한 (roles 있음)")
+    fun `JWT 변환 - 커스텀 권한 (roles 있음)`() {
+        // given
+        val jwt = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "67890"
+            every { getClaimAsString("email") } returns "admin@example.com"
+            every { claims } returns mapOf(
+                "member_id" to "67890",
+                "email" to "admin@example.com",
+                "roles" to listOf("ADMIN", "USER")
+            )
+        }
+        
+        // when
+        val result = jwtAuthConverter.convert(jwt)
+        
+        // then
+        assertNotNull(result)
+        
+        // Principal 검증
+        val principal = result.principal as MemberPrincipal
+        assertEquals(67890L, principal.memberId)
+        assertEquals("admin@example.com", principal.email)
+        
+        // 커스텀 권한 검증
+        assertEquals(2, result.authorities.size)
+        assertTrue(result.authorities.contains(SimpleGrantedAuthority("ROLE_ADMIN")))
+        assertTrue(result.authorities.contains(SimpleGrantedAuthority("ROLE_USER")))
+    }
+
+    @Test
+    @DisplayName("JWT 변환 실패 - member_id 클레임 누락")
+    fun `JWT 변환 실패 - member_id 클레임 누락`() {
+        // given
+        val jwt = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns null
+            every { getClaimAsString("email") } returns "test@example.com"
+            every { claims } returns mapOf("email" to "test@example.com")
+        }
+        
+        // when & then
+        assertThrows<JwtRequiredClaimMissingException> {
+            jwtAuthConverter.convert(jwt)
+        }
+    }
+
+    @Test
+    @DisplayName("JWT 변환 실패 - email 클레임 누락")
+    fun `JWT 변환 실패 - email 클레임 누락`() {
+        // given
+        val jwt = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "12345"
+            every { getClaimAsString("email") } returns null
+            every { claims } returns mapOf("member_id" to "12345")
+        }
+        
+        // when & then
+        assertThrows<JwtRequiredClaimMissingException> {
+            jwtAuthConverter.convert(jwt)
+        }
+    }
+
+    @Test
+    @DisplayName("JWT 변환 실패 - member_id 타입 변환 실패")
+    fun `JWT 변환 실패 - member_id 타입 변환 실패`() {
+        // given
+        val jwt = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "invalid_number"
+            every { getClaimAsString("email") } returns "test@example.com"
+            every { claims } returns mapOf(
+                "member_id" to "invalid_number",
+                "email" to "test@example.com"
+            )
+        }
+        
+        // when & then
+        assertThrows<JwtClaimFormatException> {
+            jwtAuthConverter.convert(jwt)
+        }
+    }
+
+    @Test
+    @DisplayName("JWT 변환 - 다른 입력값으로 다른 Principal 생성")
+    fun `JWT 변환 - 다른 입력값으로 다른 Principal 생성`() {
+        // given
+        val jwt1 = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "11111"
+            every { getClaimAsString("email") } returns "user1@example.com"
+            every { claims } returns mapOf(
+                "member_id" to "11111",
+                "email" to "user1@example.com"
+            )
+        }
+        
+        val jwt2 = mockk<Jwt> {
+            every { getClaimAsString("member_id") } returns "22222"
+            every { getClaimAsString("email") } returns "user2@example.com"
+            every { claims } returns mapOf(
+                "member_id" to "22222",
+                "email" to "user2@example.com"
+            )
+        }
+        
+        // when
+        val result1 = jwtAuthConverter.convert(jwt1)
+        val result2 = jwtAuthConverter.convert(jwt2)
+        
+        // then
+        val principal1 = result1.principal as MemberPrincipal
+        val principal2 = result2.principal as MemberPrincipal
+        
+        // 각각 다른 Principal 생성 검증
+        assertNotEquals(principal1.memberId, principal2.memberId)
+        assertNotEquals(principal1.email, principal2.email)
+        
+        // 각각의 값 정확성 검증
+        assertEquals(11111L, principal1.memberId)
+        assertEquals("user1@example.com", principal1.email)
+        assertEquals(22222L, principal2.memberId)
+        assertEquals("user2@example.com", principal2.email)
+        
+        // 둘 다 기본 권한 가져야 함
+        assertEquals(1, result1.authorities.size)
+        assertEquals(1, result2.authorities.size)
+        assertTrue(result1.authorities.contains(SimpleGrantedAuthority("ROLE_USER")))
+        assertTrue(result2.authorities.contains(SimpleGrantedAuthority("ROLE_USER")))
+    }
+}

--- a/src/test/kotlin/kr/co/archan/reflect/global/util/CryptoTest.kt
+++ b/src/test/kotlin/kr/co/archan/reflect/global/util/CryptoTest.kt
@@ -1,0 +1,176 @@
+package kr.co.archan.reflect.global.util
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Assertions.*
+import java.util.*
+
+class CryptoTest {
+
+    @Test
+    @DisplayName("sha256 - 기본 문자열 해시 생성")
+    fun `sha256 - 기본 문자열 해시 생성`() {
+        // given
+        val input = "hello world"
+        
+        // when
+        val result = Crypto.sha256(input)
+        
+        // then
+        assertNotNull(result)
+        assertFalse(result.isEmpty())
+        
+        // SHA-256을 Base64 URL 인코딩하면 43자 (32바이트 → 43자, 패딩 없음)
+        assertEquals(43, result.length)
+        
+        // Base64 URL 형식 검증 (패딩 없음)
+        assertFalse(result.contains('='))
+        assertTrue(result.matches(Regex("^[A-Za-z0-9_-]+$")))
+    }
+
+    @Test
+    @DisplayName("sha256 - 동일한 입력에 대해 동일한 해시 생성")
+    fun `sha256 - 동일한 입력에 대해 동일한 해시 생성`() {
+        // given
+        val input = "test string"
+        
+        // when
+        val result1 = Crypto.sha256(input)
+        val result2 = Crypto.sha256(input)
+        
+        // then
+        assertEquals(result1, result2)
+    }
+
+    @Test
+    @DisplayName("sha256 - 다른 입력에 대해 다른 해시 생성")
+    fun `sha256 - 다른 입력에 대해 다른 해시 생성`() {
+        // given
+        val input1 = "string1"
+        val input2 = "string2"
+        
+        // when
+        val result1 = Crypto.sha256(input1)
+        val result2 = Crypto.sha256(input2)
+        
+        // then
+        assertNotEquals(result1, result2)
+    }
+
+    @Test
+    @DisplayName("sha256 - 빈 문자열 해시 생성")
+    fun `sha256 - 빈 문자열 해시 생성`() {
+        // given
+        val input = ""
+        
+        // when
+        val result = Crypto.sha256(input)
+        
+        // then
+        assertNotNull(result)
+        assertEquals(43, result.length)
+        
+        // 빈 문자열의 SHA-256 해시값은 항상 동일
+        val expectedEmpty = Crypto.sha256("")
+        assertEquals(expectedEmpty, result)
+    }
+
+    @Test
+    @DisplayName("sha256 - 긴 문자열 해시 생성")
+    fun `sha256 - 긴 문자열 해시 생성`() {
+        // given
+        val input = "a".repeat(1000) // 1000자 문자열
+        
+        // when
+        val result = Crypto.sha256(input)
+        
+        // then
+        assertNotNull(result)
+        assertEquals(43, result.length) // 입력 길이와 상관없이 해시는 항상 43자
+    }
+
+    @Test
+    @DisplayName("sha256 - 특수문자 포함 문자열 해시 생성")
+    fun `sha256 - 특수문자 포함 문자열 해시 생성`() {
+        // given
+        val input = "!@#$%^&*()_+-=[]{}|;:'\",.<>?/~`"
+        
+        // when
+        val result = Crypto.sha256(input)
+        
+        // then
+        assertNotNull(result)
+        assertEquals(43, result.length)
+        assertTrue(result.matches(Regex("^[A-Za-z0-9_-]+$")))
+    }
+
+    @Test
+    @DisplayName("sha256 - 유니코드 문자열 해시 생성")
+    fun `sha256 - 유니코드 문자열 해시 생성`() {
+        // given
+        val input = "안녕하세요 🌟 こんにちは"
+        
+        // when
+        val result = Crypto.sha256(input)
+        
+        // then
+        assertNotNull(result)
+        assertEquals(43, result.length)
+        assertTrue(result.matches(Regex("^[A-Za-z0-9_-]+$")))
+    }
+
+    @Test
+    @DisplayName("sha256 - 대소문자 구분 검증")
+    fun `sha256 - 대소문자 구분 검증`() {
+        // given
+        val input1 = "Test"
+        val input2 = "test"
+        
+        // when
+        val result1 = Crypto.sha256(input1)
+        val result2 = Crypto.sha256(input2)
+        
+        // then
+        assertNotEquals(result1, result2)
+    }
+
+    @Test
+    @DisplayName("sha256 - 공백 포함 문자열 해시 생성")
+    fun `sha256 - 공백 포함 문자열 해시 생성`() {
+        // given
+        val input1 = "hello world"
+        val input2 = "helloworld"
+        val input3 = " hello world "
+        
+        // when
+        val result1 = Crypto.sha256(input1)
+        val result2 = Crypto.sha256(input2)
+        val result3 = Crypto.sha256(input3)
+        
+        // then
+        // 모두 다른 해시값이어야 함 (공백도 해시에 영향)
+        assertNotEquals(result1, result2)
+        assertNotEquals(result1, result3)
+        assertNotEquals(result2, result3)
+    }
+
+    @Test
+    @DisplayName("sha256 - Base64 URL 인코딩 형식 검증")
+    fun `sha256 - Base64 URL 인코딩 형식 검증`() {
+        // given
+        val inputs = listOf("test1", "test2", "test3", "very_long_string_for_testing")
+        
+        inputs.forEach { input ->
+            // when
+            val result = Crypto.sha256(input)
+            
+            // then
+            // Base64 URL 인코딩은 A-Z, a-z, 0-9, -, _ 만 사용 (패딩 없음)
+            assertTrue(result.matches(Regex("^[A-Za-z0-9_-]+$")), "Input: $input, Result: $result")
+            assertFalse(result.contains('+'), "Input: $input should not contain '+'")
+            assertFalse(result.contains('/'), "Input: $input should not contain '/'")
+            assertFalse(result.contains('='), "Input: $input should not contain padding '='")
+            assertEquals(43, result.length, "Input: $input should produce 43 character hash")
+        }
+    }
+}

--- a/src/test/kotlin/kr/co/archan/reflect/global/util/CryptoTest.kt
+++ b/src/test/kotlin/kr/co/archan/reflect/global/util/CryptoTest.kt
@@ -3,9 +3,17 @@ package kr.co.archan.reflect.global.util
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import java.util.*
 
 class CryptoTest {
+
+    private lateinit var crypto: Crypto
+
+    @BeforeEach
+    fun setUp() {
+        crypto = Crypto("test-secret-key")
+    }
 
     @Test
     @DisplayName("sha256 - 기본 문자열 해시 생성")
@@ -14,7 +22,7 @@ class CryptoTest {
         val input = "hello world"
         
         // when
-        val result = Crypto.sha256(input)
+        val result = crypto.sha256WithNoSalt(input)
         
         // then
         assertNotNull(result)
@@ -35,8 +43,8 @@ class CryptoTest {
         val input = "test string"
         
         // when
-        val result1 = Crypto.sha256(input)
-        val result2 = Crypto.sha256(input)
+        val result1 = crypto.sha256WithNoSalt(input)
+        val result2 = crypto.sha256WithNoSalt(input)
         
         // then
         assertEquals(result1, result2)
@@ -50,8 +58,8 @@ class CryptoTest {
         val input2 = "string2"
         
         // when
-        val result1 = Crypto.sha256(input1)
-        val result2 = Crypto.sha256(input2)
+        val result1 = crypto.sha256WithNoSalt(input1)
+        val result2 = crypto.sha256WithNoSalt(input2)
         
         // then
         assertNotEquals(result1, result2)
@@ -64,14 +72,14 @@ class CryptoTest {
         val input = ""
         
         // when
-        val result = Crypto.sha256(input)
+        val result = crypto.sha256WithNoSalt(input)
         
         // then
         assertNotNull(result)
         assertEquals(43, result.length)
         
         // 빈 문자열의 SHA-256 해시값은 항상 동일
-        val expectedEmpty = Crypto.sha256("")
+        val expectedEmpty = crypto.sha256WithNoSalt("")
         assertEquals(expectedEmpty, result)
     }
 
@@ -82,7 +90,7 @@ class CryptoTest {
         val input = "a".repeat(1000) // 1000자 문자열
         
         // when
-        val result = Crypto.sha256(input)
+        val result = crypto.sha256WithNoSalt(input)
         
         // then
         assertNotNull(result)
@@ -96,7 +104,7 @@ class CryptoTest {
         val input = "!@#$%^&*()_+-=[]{}|;:'\",.<>?/~`"
         
         // when
-        val result = Crypto.sha256(input)
+        val result = crypto.sha256WithNoSalt(input)
         
         // then
         assertNotNull(result)
@@ -111,7 +119,7 @@ class CryptoTest {
         val input = "안녕하세요 🌟 こんにちは"
         
         // when
-        val result = Crypto.sha256(input)
+        val result = crypto.sha256WithNoSalt(input)
         
         // then
         assertNotNull(result)
@@ -127,8 +135,8 @@ class CryptoTest {
         val input2 = "test"
         
         // when
-        val result1 = Crypto.sha256(input1)
-        val result2 = Crypto.sha256(input2)
+        val result1 = crypto.sha256WithNoSalt(input1)
+        val result2 = crypto.sha256WithNoSalt(input2)
         
         // then
         assertNotEquals(result1, result2)
@@ -143,9 +151,9 @@ class CryptoTest {
         val input3 = " hello world "
         
         // when
-        val result1 = Crypto.sha256(input1)
-        val result2 = Crypto.sha256(input2)
-        val result3 = Crypto.sha256(input3)
+        val result1 = crypto.sha256WithNoSalt(input1)
+        val result2 = crypto.sha256WithNoSalt(input2)
+        val result3 = crypto.sha256WithNoSalt(input3)
         
         // then
         // 모두 다른 해시값이어야 함 (공백도 해시에 영향)
@@ -162,7 +170,7 @@ class CryptoTest {
         
         inputs.forEach { input ->
             // when
-            val result = Crypto.sha256(input)
+            val result = crypto.sha256WithNoSalt(input)
             
             // then
             // Base64 URL 인코딩은 A-Z, a-z, 0-9, -, _ 만 사용 (패딩 없음)


### PR DESCRIPTION
closes #3 

Spring Security와 OAuth2ResourceServer를 이용하여 JWT 인증/인가를 구현하였습니다.

Access Token은 JWT로 생성하고 Refresh Token은 단순하게 엔트로피가 높은 랜덤한 문자열로 생성하였습니다.
Refresh Token은 Redis에 저장하여 2주동안 사용 가능하도록 만들었습니다.

또한 프론트엔드를 웹으로 개발하는것을 고려하여 refresh token은 http only쿠키로써 사용되도록 설정했고 옵션은 아래처럼 설정했습니다.

    refresh-cookie-enabled: true //모바일 클라이언트 추가 시 refresh 토큰을 쿠키로 줄 지 body로 줄 지 결정하는 옵션입니다
    refresh-cookie-name: refresh_token
    refresh-cookie-secure: false
    refresh-cookie-path: /auth
    refresh-cookie-same-site: Strict


CSRF나 CORS 설정은 프론트엔드 연동하면서 추가 할 예정입니다.

<img width="1239" height="333" alt="스크린샷 2025-09-16 오전 9 31 38" src="https://github.com/user-attachments/assets/752c8eb7-78b0-49a3-86ca-64416c5e3c8e" />
<img width="1231" height="339" alt="스크린샷 2025-09-16 오전 9 31 51" src="https://github.com/user-attachments/assets/b8763e10-5d54-4ec8-a657-db6b5a0fc574" />
<img width="1236" height="322" alt="스크린샷 2025-09-16 오전 9 31 29" src="https://github.com/user-attachments/assets/f43a6b8c-7159-40ee-bff4-e36e6083bc16" />



